### PR TITLE
refactor: replace binary assets with procedural neon visuals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Step 8: Provide OPENAI key for AI helpers
+OPENAI_API_KEY=replace-with-real-key

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,35 @@
+// Step 1: ESLint configuration aligned with Prettier
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    jest: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['react', '@typescript-eslint'],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off'
+  },
+  ignorePatterns: ['babel.config.js', 'metro.config.js', 'jest.config.js']
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Step 1: Basic Expo/TypeScript ignores
+node_modules
+.expo
+.expo-shared
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.expo
+.DS_Store
+.env
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+// Step 1: Prettier config for consistent formatting
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none",
+  "printWidth": 90
+}

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,77 @@
+// Steps 3-12: App entry hooking gesture handler, theme provider, navigation shell
+import 'react-native-gesture-handler';
+import React, { useEffect } from 'react';
+import { StatusBar } from 'expo-status-bar';
+import { NavigationContainer, DefaultTheme, DarkTheme, LinkingOptions } from '@react-navigation/native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { ThemeProvider, useNeonTheme } from './src/theme/ThemeProvider';
+import { RootDrawer } from './src/navigation/RootDrawer';
+import { initDatabase } from './src/data/db';
+import { seed } from './src/data/seed';
+import { GlobalErrorBoundary } from './src/components/GlobalErrorBoundary';
+import { ToastProvider } from './src/components/ToastProvider';
+
+const linking: LinkingOptions<Record<string, object | undefined>> = {
+  prefixes: ['vyral://', 'https://vyralverse.app'],
+  config: {
+    screens: {
+      Modules: {
+        screens: {
+          Core: 'core',
+          Lyfe: 'lyfe',
+          Stryke: 'stryke'
+        }
+      },
+      Tree: 'tree',
+      Zone: 'zone',
+      Skrybe: 'skrybe',
+      Settings: 'settings'
+    }
+  }
+};
+
+const NavigationHost: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const navTheme = theme.mode === 'dark' ? DarkTheme : DefaultTheme;
+  navTheme.colors.background = theme.colors.background;
+  navTheme.colors.card = theme.colors.surface;
+  navTheme.colors.primary = theme.colors.accent;
+  navTheme.colors.text = theme.colors.text;
+
+  return (
+    <NavigationContainer linking={linking} theme={navTheme}>
+      <RootDrawer />
+    </NavigationContainer>
+  );
+};
+
+const BootstrappedApp: React.FC = () => {
+  useEffect(() => {
+    const bootstrap = async () => {
+      await initDatabase();
+      await seed();
+    };
+    bootstrap().catch(error => {
+      console.error('Failed to bootstrap database', error);
+    });
+  }, []);
+
+  return (
+    <SafeAreaProvider>
+      <GlobalErrorBoundary>
+        <ToastProvider>
+          <NavigationHost />
+          <StatusBar style="light" />
+        </ToastProvider>
+      </GlobalErrorBoundary>
+    </SafeAreaProvider>
+  );
+};
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <BootstrappedApp />
+    </ThemeProvider>
+  );
+}

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,31 @@
+// Step 8: .env & Config wiring for Vyral Verse
+import 'dotenv/config';
+
+export default {
+  expo: {
+    name: 'Vyral Verse',
+    slug: 'vyral-verse',
+    scheme: 'vyral',
+    version: '0.1.0',
+    orientation: 'portrait',
+    userInterfaceStyle: 'dark',
+    splash: {
+      // Placeholder splash configuration until vector assets are added
+      resizeMode: 'contain',
+      backgroundColor: '#02010A'
+    },
+    assetBundlePatterns: ['**/*'],
+    ios: {
+      supportsTablet: true
+    },
+    android: {
+      package: 'com.vyralverse.app'
+    },
+    web: {
+      bundler: 'metro'
+    },
+    extra: {
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? ''
+    }
+  }
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+// Step 3: Reanimated configuration
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin' // Step 3: ensure the plugin is last
+    ]
+  };
+};

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,42 @@
+// Step 1: Flat ESLint configuration bridging TS + React Native
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooks = require('eslint-plugin-react-hooks');
+const prettierConfig = require('eslint-config-prettier');
+
+module.exports = [
+  {
+    ignores: ['node_modules/**', 'dist/**', 'coverage/**']
+  },
+  {
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true }
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      react: reactPlugin,
+      'react-hooks': reactHooks
+    },
+    settings: {
+      react: {
+        version: 'detect'
+      }
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      ...prettierConfig.rules,
+      'react/react-in-jsx-scope': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off'
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "vyral-verse",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "format": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format:write": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\""
+  },
+  "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.19.1",
+    "@react-navigation/bottom-tabs": "^6.5.11",
+    "@react-navigation/drawer": "^6.6.2",
+    "@react-navigation/native": "^6.1.6",
+    "@shopify/flash-list": "^1.5.1",
+    "dotenv": "^16.3.1",
+    "expo": "~50.0.6",
+    "expo-constants": "~15.4.5",
+    "expo-haptics": "~12.6.1",
+    "expo-linear-gradient": "~13.0.0",
+    "expo-notifications": "~0.29.7",
+    "expo-secure-store": "~12.3.1",
+    "expo-sqlite": "~11.3.1",
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "react-native-gesture-handler": "~2.14.1",
+    "react-native-reanimated": "~3.6.1",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "zustand": "^4.4.6",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@types/react": "18.2.36",
+    "@types/react-native": "0.73.0",
+    "@typescript-eslint/eslint-plugin": "^6.19.0",
+    "@typescript-eslint/parser": "^6.19.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.1.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/src/ai/lessons.ts
+++ b/src/ai/lessons.ts
@@ -1,0 +1,66 @@
+// Step 13: AI helper to build lesson outlines leveraging OpenAI when configured
+import Constants from 'expo-constants';
+
+export type LessonOutline = {
+  topic: string;
+  bullets: string[];
+};
+
+export const buildLessonOutline = async (topic: string): Promise<LessonOutline> => {
+  const key = Constants.expoConfig?.extra?.OPENAI_API_KEY;
+  if (!key) {
+    // Offline fallback blueprint keeps onboarding smooth during development
+    return {
+      topic,
+      bullets: [
+        `Define ${topic} in your own neon terms`,
+        'Map two tangible micro-actions',
+        'Lock a momentum ritual for tonight'
+      ]
+    };
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You craft actionable neon productivity lessons. Keep responses short, 3 bullet outline.'
+          },
+          { role: 'user', content: `Build a quick actionable lesson outline about ${topic}.` }
+        ],
+        max_tokens: 200
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to contact OpenAI');
+    }
+
+    const payload = await response.json();
+    const text: string = payload.choices?.[0]?.message?.content ?? '';
+    const bullets = text
+      .split('\n')
+      .map(line => line.replace(/^[-*\d\.\s]+/, '').trim())
+      .filter(Boolean)
+      .slice(0, 3);
+    return { topic, bullets: bullets.length ? bullets : [`Momentum insight on ${topic}`] };
+  } catch (error) {
+    return {
+      topic,
+      bullets: [
+        `Rapid reframing: ${topic}`,
+        'Pinpoint one friction source',
+        'Experiment with a neon micro-shift'
+      ]
+    };
+  }
+};

--- a/src/components/GlobalErrorBoundary.tsx
+++ b/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,61 @@
+// Step 22: Global error boundary to guard the neon OS shell
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { NeonButton } from './NeonButton';
+import { NeonBackground } from './NeonBackground';
+
+export class GlobalErrorBoundary extends React.Component<React.PropsWithChildren, { hasError: boolean }> {
+  constructor(props: React.PropsWithChildren) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('Vyral Verse crash captured', error, info);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <NeonBackground>
+          <View style={styles.container}>
+            <Text style={styles.title}>Signal Lost</Text>
+            <Text style={styles.body}>We caught a glitch. Reset to dive back in.</Text>
+            <NeonButton label="Reset" onPress={this.reset} />
+          </View>
+        </NeonBackground>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    marginBottom: 16
+  },
+  body: {
+    fontSize: 16,
+    color: '#D0CCFF',
+    marginBottom: 24,
+    textAlign: 'center'
+  }
+});

--- a/src/components/NeoMascot.tsx
+++ b/src/components/NeoMascot.tsx
@@ -1,0 +1,116 @@
+// Step 19: Neo mascot assistant reacting to milestones
+import React, { useMemo } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeOut,
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle
+} from 'react-native-reanimated';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useNeoStore } from '../state/neoStore';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+type MascotVisual = {
+  glyph: string;
+  gradient: string[];
+};
+
+const mascotVisuals: Record<'idle' | 'celebrate' | 'alert', MascotVisual> = {
+  idle: {
+    glyph: '◎',
+    gradient: ['rgba(120,98,255,0.9)', 'rgba(9,9,40,0.9)']
+  },
+  celebrate: {
+    glyph: '✶',
+    gradient: ['rgba(42,255,210,1)', 'rgba(42,96,255,0.9)']
+  },
+  alert: {
+    glyph: '⚡',
+    gradient: ['rgba(255,121,91,1)', 'rgba(146,42,255,0.9)']
+  }
+};
+
+export const NeoMascot: React.FC = () => {
+  const { state, message, acknowledge } = useNeoStore();
+  const { theme } = useNeonTheme();
+  const { colors, spacing, radii } = theme;
+  const scale = useSharedValue(0.9);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }]
+  }));
+
+  const visual = useMemo(() => mascotVisuals[state], [state]);
+  const glyphColor = theme.mode === 'dark' ? '#04010F' : '#F5F5FF';
+
+  const handlePress = () => {
+    scale.value = withTiming(1.05, { duration: 180 }, () => {
+      scale.value = withTiming(1, { duration: 140 });
+    });
+    acknowledge();
+  };
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Animated.View entering={FadeIn.delay(200)} exiting={FadeOut} style={styles.container}>
+      <Pressable onPress={handlePress} style={styles.pressable} accessibilityRole="button">
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: colors.surfaceAlt,
+            borderRadius: radii.lg,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderWidth: 1,
+            borderColor: colors.border
+          }}
+        >
+          <Animated.View style={[{ marginRight: spacing.sm }, animatedStyle]}>
+            <LinearGradient
+              colors={visual.gradient}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={styles.mascotBubble}
+            >
+              <Text style={[styles.glyph, { color: glyphColor }]}>{visual.glyph}</Text>
+            </LinearGradient>
+          </Animated.View>
+          <Text style={[styles.text, { color: colors.text }]}>{message}</Text>
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 40,
+    right: 16
+  },
+  pressable: {
+    maxWidth: 280
+  },
+  mascotBubble: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)'
+  },
+  glyph: {
+    fontSize: 20,
+    fontWeight: '700'
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '600'
+  }
+});

--- a/src/components/NeonBackground.tsx
+++ b/src/components/NeonBackground.tsx
@@ -1,0 +1,42 @@
+// Step 7: Neon background primitive for immersive gradients
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+export type NeonBackgroundProps = React.PropsWithChildren<{
+  variant?: 'purple' | 'cyan';
+}>;
+
+const gradientMap: Record<'purple' | 'cyan', string[]> = {
+  purple: ['rgba(127,91,255,0.85)', 'rgba(20,240,255,0.2)'],
+  cyan: ['rgba(0,212,255,0.85)', 'rgba(108,91,255,0.2)']
+};
+
+export const NeonBackground: React.FC<NeonBackgroundProps> = ({ children, variant = 'purple' }) => {
+  const {
+    theme: {
+      colors: { background }
+    }
+  } = useNeonTheme();
+
+  const colors = [background, ...gradientMap[variant]];
+
+  return (
+    <View style={styles.container}>
+      <LinearGradient
+        colors={colors}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={StyleSheet.absoluteFill}
+      />
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  }
+});

--- a/src/components/NeonButton.tsx
+++ b/src/components/NeonButton.tsx
@@ -1,0 +1,71 @@
+// Step 7: Neon button with gradient fill and subtle interactions
+import React from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+export type NeonButtonProps = {
+  label: string;
+  onPress?: () => void;
+  icon?: React.ReactNode;
+};
+
+export const NeonButton: React.FC<NeonButtonProps> = ({ label, onPress, icon }) => {
+  const {
+    theme: { colors, radii, spacing }
+  } = useNeonTheme();
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }]
+  }));
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => {
+        scale.value = withSpring(0.96, { damping: 12, stiffness: 120 });
+      }}
+      onPressOut={() => {
+        scale.value = withSpring(1, { damping: 12, stiffness: 120 });
+      }}
+      style={styles.pressable}
+    >
+      <Animated.View style={[styles.wrapper, animatedStyle]}> 
+        <LinearGradient
+          colors={[colors.accent, colors.accentSecondary]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={{
+            borderRadius: radii.lg,
+            paddingVertical: spacing.sm,
+            paddingHorizontal: spacing.lg,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          {icon}
+          <Text style={[styles.label, { color: '#04010F' }]}>{label}</Text>
+        </LinearGradient>
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  pressable: {
+    width: '100%'
+  },
+  wrapper: {
+    width: '100%'
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginLeft: 8
+  }
+});

--- a/src/components/NeonCard.tsx
+++ b/src/components/NeonCard.tsx
@@ -1,0 +1,43 @@
+// Step 7: Animated neon card component
+import React from 'react';
+import Animated, { FadeInUp, FadeOutDown } from 'react-native-reanimated';
+import { StyleSheet, ViewStyle } from 'react-native';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+export type NeonCardProps = React.PropsWithChildren<{
+  style?: ViewStyle;
+}>;
+
+export const NeonCard: React.FC<NeonCardProps> = ({ children, style }) => {
+  const {
+    theme: { colors, radii, spacing, shadows },
+    accent
+  } = useNeonTheme();
+
+  return (
+    <Animated.View
+      entering={FadeInUp.springify().damping(14).mass(0.9)}
+      exiting={FadeOutDown.duration(180)}
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.surface,
+          borderRadius: radii.lg,
+          padding: spacing.lg,
+          borderWidth: 1,
+          borderColor: colors.border,
+          ...shadows.neon(accent)
+        },
+        style
+      ]}
+    >
+      {children}
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    width: '100%'
+  }
+});

--- a/src/components/NeonGlyph.tsx
+++ b/src/components/NeonGlyph.tsx
@@ -1,0 +1,39 @@
+// Step 7: Glyph badge used where binary icons were previously referenced
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+type NeonGlyphProps = {
+  label: string;
+  size?: number;
+};
+
+export const NeonGlyph: React.FC<NeonGlyphProps> = ({ label, size = 18 }) => {
+  const { theme } = useNeonTheme();
+  const dimension = size + 12;
+  const textColor = theme.mode === 'dark' ? '#04010F' : '#F5F5FF';
+
+  return (
+    <LinearGradient
+      colors={[theme.colors.accent, theme.colors.accentSecondary]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={[styles.container, { width: dimension, height: dimension, borderRadius: dimension / 2 }]}
+    >
+      <Text style={[styles.label, { fontSize: size * 0.75, color: textColor }]}>{label}</Text>
+    </LinearGradient>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)'
+  },
+  label: {
+    fontWeight: '700'
+  }
+});

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,56 @@
+// Step 22: Toast provider for user feedback
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { Text, StyleSheet } from 'react-native';
+import Animated, { FadeInDown, FadeOutUp } from 'react-native-reanimated';
+import { useNeonTheme } from '../theme/ThemeProvider';
+
+const ToastContext = createContext<{ showToast: (message: string) => void } | undefined>(undefined);
+
+export const ToastProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [message, setMessage] = useState<string | null>(null);
+  const { theme } = useNeonTheme();
+
+  const showToast = useCallback((text: string) => {
+    setMessage(text);
+    setTimeout(() => setMessage(null), 2200);
+  }, []);
+
+  const value = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {message && (
+        <Animated.View
+          entering={FadeInDown}
+          exiting={FadeOutUp}
+          style={[styles.toast, { backgroundColor: theme.colors.surfaceAlt, borderColor: theme.colors.border }]}
+          pointerEvents="none"
+        >
+          <Text style={{ color: theme.colors.text }}>{message}</Text>
+        </Animated.View>
+      )}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return context;
+};
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    bottom: 48,
+    left: 24,
+    right: 24,
+    padding: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    alignItems: 'center'
+  }
+});

--- a/src/data/db.ts
+++ b/src/data/db.ts
@@ -1,0 +1,147 @@
+// Step 9: SQLite database bootstrap and migrations
+import * as SQLite from 'expo-sqlite';
+
+export type SQLParams = (string | number | null)[];
+
+const database = SQLite.openDatabase('vyralverse.db');
+
+const MIGRATIONS: { id: string; statements: string[] }[] = [
+  {
+    id: '0001_init_core',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS core_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel TEXT NOT NULL,
+        author TEXT NOT NULL,
+        content TEXT NOT NULL,
+        avatar TEXT,
+        created_at INTEGER NOT NULL
+      )`
+    ]
+  },
+  {
+    id: '0002_init_lyfe',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS lyfe_lessons (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        topic TEXT NOT NULL,
+        outline TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )`,
+      `CREATE TABLE IF NOT EXISTS lyfe_progress (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        lesson_id INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        xp INTEGER NOT NULL DEFAULT 0,
+        completed_at INTEGER,
+        FOREIGN KEY(lesson_id) REFERENCES lyfe_lessons(id)
+      )`
+    ]
+  },
+  {
+    id: '0003_init_stryke',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS stryke_choices (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        scenario_id TEXT NOT NULL,
+        option_id TEXT NOT NULL,
+        effect TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )`
+    ]
+  },
+  {
+    id: '0004_init_tree',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS tree_nodes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        parent_id INTEGER,
+        title TEXT NOT NULL,
+        hint TEXT,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY(parent_id) REFERENCES tree_nodes(id)
+      )`
+    ]
+  },
+  {
+    id: '0005_init_zone',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS zone_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        author TEXT NOT NULL,
+        body TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        reactions INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL
+      )`
+    ]
+  },
+  {
+    id: '0006_init_skrybe',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS skrybe_notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
+        word_count INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      )`
+    ]
+  },
+  {
+    id: '0007_init_prefs',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS user_prefs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT UNIQUE NOT NULL,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )`
+    ]
+  }
+];
+
+export const executeSql = (sql: string, params: SQLParams = []): Promise<SQLite.SQLResultSet> =>
+  new Promise((resolve, reject) => {
+    database.transaction(
+      tx => {
+        tx.executeSql(
+          sql,
+          params,
+          (_, result) => {
+            resolve(result);
+            return false;
+          },
+          (_, error) => {
+            reject(error);
+            return false;
+          }
+        );
+      },
+      error => reject(error)
+    );
+  });
+
+export const initDatabase = async (): Promise<void> => {
+  await executeSql(
+    `CREATE TABLE IF NOT EXISTS migrations (
+      id TEXT PRIMARY KEY,
+      run_at INTEGER NOT NULL
+    )`
+  );
+
+  for (const migration of MIGRATIONS) {
+    const existing = await executeSql('SELECT id FROM migrations WHERE id = ?', [migration.id]);
+    if (existing.rows.length === 0) {
+      for (const statement of migration.statements) {
+        await executeSql(statement);
+      }
+      await executeSql('INSERT INTO migrations (id, run_at) VALUES (?, ?)', [
+        migration.id,
+        Date.now()
+      ]);
+    }
+  }
+};
+
+export default database;

--- a/src/data/repos/coreMessagesRepo.ts
+++ b/src/data/repos/coreMessagesRepo.ts
@@ -1,0 +1,41 @@
+// Step 10: Repository layer with Zod validation for Core module
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const coreMessageSchema = z.object({
+  id: z.number().optional(),
+  channel: z.string(),
+  author: z.string(),
+  content: z.string(),
+  avatar: z.string().nullable().optional(),
+  created_at: z.number()
+});
+
+export type CoreMessage = z.infer<typeof coreMessageSchema>;
+
+const mapRows = (rows: any[]): CoreMessage[] => rows.map(row => coreMessageSchema.parse(row));
+
+export const CoreMessagesRepo = {
+  async list(channel: string): Promise<CoreMessage[]> {
+    const result = await executeSql(
+      'SELECT * FROM core_messages WHERE channel = ? ORDER BY created_at ASC',
+      [channel]
+    );
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return mapRows(rows);
+  },
+  async add(message: Omit<CoreMessage, 'id'>): Promise<CoreMessage> {
+    const validated = coreMessageSchema.omit({ id: true }).parse(message);
+    const result = await executeSql(
+      'INSERT INTO core_messages (channel, author, content, avatar, created_at) VALUES (?, ?, ?, ?, ?)',
+      [
+        validated.channel,
+        validated.author,
+        validated.content,
+        validated.avatar ?? null,
+        validated.created_at
+      ]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  }
+};

--- a/src/data/repos/lyfeLessonsRepo.ts
+++ b/src/data/repos/lyfeLessonsRepo.ts
@@ -1,0 +1,58 @@
+// Step 10: Repository for Lyfe lessons and progress tracking
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const lessonSchema = z.object({
+  id: z.number().optional(),
+  topic: z.string(),
+  outline: z.string(),
+  created_at: z.number()
+});
+
+const progressSchema = z.object({
+  id: z.number().optional(),
+  lesson_id: z.number(),
+  status: z.enum(['pending', 'in-progress', 'complete']),
+  xp: z.number(),
+  completed_at: z.number().nullable()
+});
+
+export type LyfeLesson = z.infer<typeof lessonSchema>;
+export type LyfeProgress = z.infer<typeof progressSchema>;
+
+const mapRows = <T>(schema: z.ZodType<T>, rows: any[]): T[] => rows.map(row => schema.parse(row));
+
+export const LyfeLessonsRepo = {
+  async list(): Promise<LyfeLesson[]> {
+    const result = await executeSql('SELECT * FROM lyfe_lessons ORDER BY created_at DESC');
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return mapRows(lessonSchema, rows);
+  },
+  async add(lesson: Omit<LyfeLesson, 'id'>): Promise<LyfeLesson> {
+    const validated = lessonSchema.omit({ id: true }).parse(lesson);
+    const result = await executeSql(
+      'INSERT INTO lyfe_lessons (topic, outline, created_at) VALUES (?, ?, ?)',
+      [validated.topic, validated.outline, validated.created_at]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  },
+  async upsertProgress(progress: Omit<LyfeProgress, 'id'>): Promise<void> {
+    const validated = progressSchema.omit({ id: true }).parse(progress);
+    await executeSql(
+      `INSERT INTO lyfe_progress (lesson_id, status, xp, completed_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(lesson_id) DO UPDATE SET status = excluded.status, xp = excluded.xp, completed_at = excluded.completed_at`,
+      [
+        validated.lesson_id,
+        validated.status,
+        validated.xp,
+        validated.completed_at ?? null
+      ]
+    );
+  },
+  async listProgress(): Promise<LyfeProgress[]> {
+    const result = await executeSql('SELECT * FROM lyfe_progress ORDER BY lesson_id ASC');
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return mapRows(progressSchema, rows);
+  }
+};

--- a/src/data/repos/skrybeNotesRepo.ts
+++ b/src/data/repos/skrybeNotesRepo.ts
@@ -1,0 +1,32 @@
+// Step 10: Repository for Skrybe creative notes
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const noteSchema = z.object({
+  id: z.number().optional(),
+  title: z.string(),
+  body: z.string(),
+  word_count: z.number(),
+  updated_at: z.number()
+});
+
+export type SkrybeNote = z.infer<typeof noteSchema>;
+
+export const SkrybeNotesRepo = {
+  async list(): Promise<SkrybeNote[]> {
+    const result = await executeSql('SELECT * FROM skrybe_notes ORDER BY updated_at DESC');
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return rows.map(row => noteSchema.parse(row));
+  },
+  async add(note: Omit<SkrybeNote, 'id'>): Promise<SkrybeNote> {
+    const validated = noteSchema.omit({ id: true }).parse(note);
+    const result = await executeSql(
+      'INSERT INTO skrybe_notes (title, body, word_count, updated_at) VALUES (?, ?, ?, ?)',
+      [validated.title, validated.body, validated.word_count, validated.updated_at]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  },
+  async remove(id: number): Promise<void> {
+    await executeSql('DELETE FROM skrybe_notes WHERE id = ?', [id]);
+  }
+};

--- a/src/data/repos/strykeChoicesRepo.ts
+++ b/src/data/repos/strykeChoicesRepo.ts
@@ -1,0 +1,32 @@
+// Step 10: Repository for Stryke branching decisions
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const choiceSchema = z.object({
+  id: z.number().optional(),
+  scenario_id: z.string(),
+  option_id: z.string(),
+  effect: z.string(),
+  created_at: z.number()
+});
+
+export type StrykeChoice = z.infer<typeof choiceSchema>;
+
+export const StrykeChoicesRepo = {
+  async listByScenario(scenarioId: string): Promise<StrykeChoice[]> {
+    const result = await executeSql(
+      'SELECT * FROM stryke_choices WHERE scenario_id = ? ORDER BY created_at DESC',
+      [scenarioId]
+    );
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return rows.map(row => choiceSchema.parse(row));
+  },
+  async add(choice: Omit<StrykeChoice, 'id'>): Promise<StrykeChoice> {
+    const validated = choiceSchema.omit({ id: true }).parse(choice);
+    const result = await executeSql(
+      'INSERT INTO stryke_choices (scenario_id, option_id, effect, created_at) VALUES (?, ?, ?, ?)',
+      [validated.scenario_id, validated.option_id, validated.effect, validated.created_at]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  }
+};

--- a/src/data/repos/treeNodesRepo.ts
+++ b/src/data/repos/treeNodesRepo.ts
@@ -1,0 +1,34 @@
+// Step 10: Repository for Tree goal map
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const nodeSchema = z.object({
+  id: z.number().optional(),
+  parent_id: z.number().nullable(),
+  title: z.string(),
+  hint: z.string().nullable(),
+  created_at: z.number()
+});
+
+export type TreeNodeRecord = z.infer<typeof nodeSchema>;
+
+export const TreeNodesRepo = {
+  async listChildren(parentId: number | null): Promise<TreeNodeRecord[]> {
+    const comparator = parentId === null ? 'IS NULL' : '= ?';
+    const params = parentId === null ? [] : [parentId];
+    const result = await executeSql(
+      `SELECT * FROM tree_nodes WHERE parent_id ${comparator} ORDER BY created_at ASC`,
+      params
+    );
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return rows.map(row => nodeSchema.parse(row));
+  },
+  async add(node: Omit<TreeNodeRecord, 'id'>): Promise<TreeNodeRecord> {
+    const validated = nodeSchema.omit({ id: true }).parse(node);
+    const result = await executeSql(
+      'INSERT INTO tree_nodes (parent_id, title, hint, created_at) VALUES (?, ?, ?, ?)',
+      [validated.parent_id ?? null, validated.title, validated.hint ?? null, validated.created_at]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  }
+};

--- a/src/data/repos/userPrefsRepo.ts
+++ b/src/data/repos/userPrefsRepo.ts
@@ -1,0 +1,31 @@
+// Step 10: Repository for persisted user preferences
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const prefSchema = z.object({
+  id: z.number().optional(),
+  key: z.string(),
+  value: z.string(),
+  updated_at: z.number()
+});
+
+export type UserPref = z.infer<typeof prefSchema>;
+
+export const UserPrefsRepo = {
+  async get(key: string): Promise<UserPref | undefined> {
+    const result = await executeSql('SELECT * FROM user_prefs WHERE key = ? LIMIT 1', [key]);
+    if (result.rows.length === 0) {
+      return undefined;
+    }
+    return prefSchema.parse(result.rows.item(0));
+  },
+  async set(key: string, value: string): Promise<void> {
+    const now = Date.now();
+    await executeSql(
+      `INSERT INTO user_prefs (key, value, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      [key, value, now]
+    );
+  }
+};

--- a/src/data/repos/zonePostsRepo.ts
+++ b/src/data/repos/zonePostsRepo.ts
@@ -1,0 +1,36 @@
+// Step 10: Repository for Zone community posts
+import { z } from 'zod';
+import { executeSql } from '../db';
+
+const postSchema = z.object({
+  id: z.number().optional(),
+  author: z.string(),
+  body: z.string(),
+  pinned: z.number(),
+  reactions: z.number(),
+  created_at: z.number()
+});
+
+export type ZonePost = z.infer<typeof postSchema>;
+
+export const ZonePostsRepo = {
+  async list(): Promise<ZonePost[]> {
+    const result = await executeSql('SELECT * FROM zone_posts ORDER BY pinned DESC, created_at DESC');
+    const rows = Array.from({ length: result.rows.length }, (_, i) => result.rows.item(i));
+    return rows.map(row => postSchema.parse(row));
+  },
+  async add(post: Omit<ZonePost, 'id'>): Promise<ZonePost> {
+    const validated = postSchema.omit({ id: true }).parse(post);
+    const result = await executeSql(
+      'INSERT INTO zone_posts (author, body, pinned, reactions, created_at) VALUES (?, ?, ?, ?, ?)',
+      [validated.author, validated.body, validated.pinned, validated.reactions, validated.created_at]
+    );
+    return { ...validated, id: result.insertId ?? undefined };
+  },
+  async updatePinned(id: number, pinned: boolean): Promise<void> {
+    await executeSql('UPDATE zone_posts SET pinned = ? WHERE id = ?', [pinned ? 1 : 0, id]);
+  },
+  async delete(id: number): Promise<void> {
+    await executeSql('DELETE FROM zone_posts WHERE id = ?', [id]);
+  }
+};

--- a/src/data/seed.ts
+++ b/src/data/seed.ts
@@ -1,0 +1,51 @@
+// Step 26: Seed helper to populate demo content for Vyral Verse
+import { CoreMessagesRepo } from './repos/coreMessagesRepo';
+import { LyfeLessonsRepo } from './repos/lyfeLessonsRepo';
+import { ZonePostsRepo } from './repos/zonePostsRepo';
+import { TreeNodesRepo } from './repos/treeNodesRepo';
+import { SkrybeNotesRepo } from './repos/skrybeNotesRepo';
+
+export const seed = async (): Promise<void> => {
+  await CoreMessagesRepo.add({
+    channel: 'core',
+    author: 'Neo',
+    content: 'Welcome to Vyral Verse — ignite your neon flow.',
+    avatar: 'neo',
+    created_at: Date.now()
+  });
+
+  const lesson = await LyfeLessonsRepo.add({
+    topic: 'Neon Habits 101',
+    outline: JSON.stringify(['Prime your focus', 'Track micro wins', 'Celebrate streaks']),
+    created_at: Date.now()
+  });
+
+  await LyfeLessonsRepo.upsertProgress({
+    lesson_id: lesson.id ?? 0,
+    status: 'in-progress',
+    xp: 120,
+    completed_at: null
+  });
+
+  await ZonePostsRepo.add({
+    author: 'V Team',
+    body: 'Drop your latest momentum move in the Zone.',
+    pinned: 1,
+    reactions: 7,
+    created_at: Date.now()
+  });
+
+  await TreeNodesRepo.add({
+    parent_id: null,
+    title: 'Foundational Flow',
+    hint: 'Calibrate your daily rhythm.',
+    created_at: Date.now()
+  });
+
+  await SkrybeNotesRepo.add({
+    title: 'Manifesto Draft',
+    body: 'Sketch the Vyral principles in three pulses.',
+    word_count: 12,
+    updated_at: Date.now()
+  });
+};

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -1,0 +1,17 @@
+// Utility hook to run async effects with cleanup (supports future steps)
+import { useEffect, DependencyList } from 'react';
+
+export const useAsyncEffect = (effect: () => Promise<void>, deps: DependencyList) => {
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      await effect();
+    };
+    run();
+    return () => {
+      mounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+  return null;
+};

--- a/src/navigation/RootDrawer.tsx
+++ b/src/navigation/RootDrawer.tsx
@@ -1,0 +1,146 @@
+// Step 6: Navigation shell — drawer + nested tabs with neon header
+import React from 'react';
+import { Text, StyleSheet, View } from 'react-native';
+import { createDrawerNavigator, DrawerContentScrollView, DrawerItemList } from '@react-navigation/drawer';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNeonTheme } from '../theme/ThemeProvider';
+import { CoreScreen } from '../screens/Core';
+import { LyfeScreen } from '../screens/Lyfe';
+import { StrykeScreen } from '../screens/Stryke';
+import { TreeScreen } from '../screens/Tree';
+import { ZoneScreen } from '../screens/Zone';
+import { SkrybeScreen } from '../screens/Skrybe';
+import { SettingsScreen } from '../screens/Settings';
+import { NeonGlyph } from '../components/NeonGlyph';
+
+const Drawer = createDrawerNavigator();
+const Tab = createBottomTabNavigator();
+
+const TabNavigator = () => {
+  const { theme } = useNeonTheme();
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: theme.colors.surfaceAlt,
+          borderTopColor: theme.colors.border
+        },
+        tabBarActiveTintColor: theme.colors.accent,
+        tabBarInactiveTintColor: theme.colors.textMuted,
+        tabBarIcon: () => <NeonGlyph label={getGlyphForRoute(route.name)} size={16} />
+      })}
+    >
+      <Tab.Screen name="Core" component={CoreScreen} />
+      <Tab.Screen name="Lyfe" component={LyfeScreen} />
+      <Tab.Screen name="Stryke" component={StrykeScreen} />
+    </Tab.Navigator>
+  );
+};
+
+const GradientHeader: React.FC<{ title: string }> = ({ title }) => {
+  const { top } = useSafeAreaInsets();
+  const { theme } = useNeonTheme();
+  return (
+    <LinearGradient
+      colors={[theme.colors.surfaceAlt, 'transparent']}
+      style={[styles.header, { paddingTop: top + 16 }]}
+    >
+      <Text style={[styles.headerText, { color: theme.colors.text }]}>{title}</Text>
+    </LinearGradient>
+  );
+};
+
+const CustomDrawerContent = (props: any) => {
+  const { theme } = useNeonTheme();
+  return (
+    <DrawerContentScrollView {...props} contentContainerStyle={{ paddingTop: 0 }}>
+      <LinearGradient colors={[theme.colors.surfaceAlt, 'transparent']} style={{ padding: 24 }}>
+        <View style={styles.drawerIcon}>
+          <NeonGlyph label="V" size={22} />
+        </View>
+        <Text style={[styles.drawerTitle, { color: theme.colors.text }]}>Vyral Verse</Text>
+        <Text style={{ color: theme.colors.textMuted }}>Neon OS shell</Text>
+      </LinearGradient>
+      <DrawerItemList {...props} />
+    </DrawerContentScrollView>
+  );
+};
+
+const glyphMap: Record<string, string> = {
+  Core: 'C',
+  Lyfe: 'L',
+  Stryke: '⚔',
+  Tree: 'T',
+  Zone: 'Z',
+  Skrybe: 'S',
+  Settings: '⚙',
+  Modules: 'M'
+};
+
+const getGlyphForRoute = (name: string) => glyphMap[name] ?? '◎';
+
+export const RootDrawer: React.FC = () => {
+  const { theme } = useNeonTheme();
+  return (
+    <Drawer.Navigator
+      drawerContent={props => <CustomDrawerContent {...props} />}
+      screenOptions={{
+        header: ({ route }) => <GradientHeader title={route.name} />,
+        drawerActiveTintColor: theme.colors.accent,
+        drawerInactiveTintColor: theme.colors.textMuted,
+        drawerStyle: { backgroundColor: theme.colors.surface }
+      }}
+    >
+      <Drawer.Screen
+        name="Modules"
+        component={TabNavigator}
+        options={{ drawerIcon: () => <NeonGlyph label={getGlyphForRoute('Modules')} size={16} /> }}
+      />
+      <Drawer.Screen
+        name="Tree"
+        component={TreeScreen}
+        options={{ drawerIcon: () => <NeonGlyph label={getGlyphForRoute('Tree')} size={16} /> }}
+      />
+      <Drawer.Screen
+        name="Zone"
+        component={ZoneScreen}
+        options={{ drawerIcon: () => <NeonGlyph label={getGlyphForRoute('Zone')} size={16} /> }}
+      />
+      <Drawer.Screen
+        name="Skrybe"
+        component={SkrybeScreen}
+        options={{ drawerIcon: () => <NeonGlyph label={getGlyphForRoute('Skrybe')} size={16} /> }}
+      />
+      <Drawer.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={{ drawerIcon: () => <NeonGlyph label={getGlyphForRoute('Settings')} size={16} /> }}
+      />
+    </Drawer.Navigator>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: 24,
+    paddingBottom: 16
+  },
+  headerText: {
+    fontSize: 22,
+    fontWeight: '700'
+  },
+  drawerIcon: {
+    width: 48,
+    height: 48,
+    marginBottom: 12,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  drawerTitle: {
+    fontSize: 20,
+    fontWeight: '700'
+  }
+});

--- a/src/screens/Core/index.tsx
+++ b/src/screens/Core/index.tsx
@@ -1,0 +1,118 @@
+// Step 12: Core collaborative chat screen wiring FlashList + composer
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+import { useFocusEffect } from '@react-navigation/native';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useCoreStore } from '../../state/coreStore';
+import { NeoMascot } from '../../components/NeoMascot';
+import { useToast } from '../../components/ToastProvider';
+
+export const CoreScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { messages, load, sendMessage } = useCoreStore();
+  const [input, setInput] = useState('');
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    load('core');
+  }, [load]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load('core');
+    }, [load])
+  );
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+    const ok = await sendMessage(input);
+    if (ok) {
+      showToast('Signal fired to the Core grid.');
+      setInput('');
+    }
+  };
+
+  return (
+    <NeonBackground>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: 'padding', android: undefined })}
+        style={styles.flex}
+      >
+        <View style={[styles.container, { padding: theme.spacing.lg }]}
+ accessibilityRole="main">
+          <Text style={[styles.heading, { color: theme.colors.text }]}>Core Grid</Text>
+          <FlashList
+            data={messages}
+            keyExtractor={item => String(item.id)}
+            renderItem={({ item }) => (
+              <NeonCard style={{ marginBottom: theme.spacing.md }}>
+                <Text style={[styles.author, { color: theme.colors.accent }]}>{item.author}</Text>
+                <Text style={{ color: theme.colors.text, marginTop: theme.spacing.xs }}>
+                  {item.content}
+                </Text>
+                <Text style={[styles.timestamp, { color: theme.colors.textMuted }]}> 
+                  {new Date(item.created_at).toLocaleTimeString()}
+                </Text>
+              </NeonCard>
+            )}
+            estimatedItemSize={160}
+            contentContainerStyle={{ paddingBottom: 120 }}
+          />
+          <View style={[styles.composer, { backgroundColor: theme.colors.surfaceAlt }]}
+ accessibilityRole="form">
+            <TextInput
+              value={input}
+              onChangeText={setInput}
+              placeholder="Signal your update..."
+              placeholderTextColor={theme.colors.textMuted}
+              style={[styles.input, { color: theme.colors.text }]}
+              multiline
+            />
+            <NeonButton label="Transmit" onPress={handleSend} />
+          </View>
+        </View>
+        <NeoMascot />
+      </KeyboardAvoidingView>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1
+  },
+  container: {
+    flex: 1
+  },
+  heading: {
+    fontSize: 32,
+    fontWeight: '700',
+    letterSpacing: 1.2,
+    marginBottom: 24
+  },
+  composer: {
+    borderRadius: 24,
+    padding: 16,
+    gap: 12,
+    position: 'absolute',
+    bottom: 16,
+    left: 16,
+    right: 16
+  },
+  input: {
+    minHeight: 60,
+    fontSize: 16
+  },
+  author: {
+    fontSize: 14,
+    fontWeight: '700'
+  },
+  timestamp: {
+    fontSize: 12,
+    marginTop: 12
+  }
+});

--- a/src/screens/Lyfe/index.tsx
+++ b/src/screens/Lyfe/index.tsx
@@ -1,0 +1,98 @@
+// Step 13: Lyfe module — AI lessons with XP tracking
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TextInput, ScrollView } from 'react-native';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useToast } from '../../components/ToastProvider';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useLyfeStore } from '../../state/lyfeStore';
+
+export const LyfeScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { lessons, progress, hydrate, generateLesson, markComplete, loading } = useLyfeStore();
+  const [topic, setTopic] = useState('Flow Rituals');
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <NeonBackground variant="cyan">
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: theme.spacing.lg, gap: theme.spacing.lg }}
+      >
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Lyfe Lessons</Text>
+        <NeonCard>
+          <Text style={[styles.subheading, { color: theme.colors.text }]}>Summon a lesson</Text>
+          <TextInput
+            value={topic}
+            onChangeText={setTopic}
+            style={[styles.input, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Topic"
+            placeholderTextColor={theme.colors.textMuted}
+          />
+          <NeonButton
+            label={loading ? 'Generating...' : 'Generate Outline'}
+            onPress={async () => {
+              await generateLesson(topic);
+              showToast('New Lyfe outline generated.');
+            }}
+          />
+        </NeonCard>
+        {lessons.map(lesson => {
+          const progressEntry = progress.find(item => item.lesson_id === lesson.id);
+          const bullets: string[] = JSON.parse(lesson.outline);
+          const completion = progressEntry?.status === 'complete';
+          return (
+            <NeonCard key={lesson.id}>
+              <Text style={[styles.lessonTitle, { color: theme.colors.accent }]}>{lesson.topic}</Text>
+              {bullets.map(bullet => (
+                <Text key={bullet} style={{ color: theme.colors.text, marginTop: theme.spacing.xs }}>
+                  • {bullet}
+                </Text>
+              ))}
+              <Text style={{ color: theme.colors.textMuted, marginTop: theme.spacing.md }}>
+                XP: {progressEntry?.xp ?? 0}
+              </Text>
+              {!completion && (
+                <NeonButton
+                  label="Mark Complete"
+                  onPress={async () => {
+                    await markComplete(lesson.id ?? 0);
+                    showToast('Lesson marked complete.');
+                  }}
+                />
+              )}
+            </NeonCard>
+          );
+        })}
+      </ScrollView>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 32,
+    fontWeight: '700'
+  },
+  subheading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 12,
+    marginBottom: 16
+  },
+  lessonTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 12
+  }
+});

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -1,0 +1,132 @@
+// Step 18: Settings control center for personalization + haptics scaffold
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, Switch, Pressable } from 'react-native';
+import { PanGestureHandler } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { accentPalette, NeonAccent } from '../../theme/tokens';
+
+const sliderWidth = 240;
+const thumbSize = 28;
+
+export const SettingsScreen: React.FC = () => {
+  const { mode, toggleMode, setAccent, theme, setFontScale, fontScale } = useNeonTheme();
+  const offset = useSharedValue((fontScale - 0.8) / (1.4 - 0.8) * (sliderWidth - thumbSize));
+  React.useEffect(() => {
+    offset.value = (fontScale - 0.8) / (1.4 - 0.8) * (sliderWidth - thumbSize);
+  }, [fontScale, offset]);
+
+  const onGesture = useAnimatedGestureHandler({
+    onStart: (_, ctx: any) => {
+      ctx.start = offset.value;
+    },
+    onActive: (event, ctx: any) => {
+      const next = Math.min(Math.max(ctx.start + event.translationX, 0), sliderWidth - thumbSize);
+      offset.value = next;
+    },
+    onEnd: () => {
+      offset.value = withSpring(Math.round(offset.value));
+    }
+  });
+
+  const animatedThumb = useAnimatedStyle(() => ({
+    transform: [{ translateX: offset.value }]
+  }));
+
+  const accentOptions = useMemo(() => Object.keys(accentPalette) as NeonAccent[], []);
+
+  const handleCommitFontScale = () => {
+    const ratio = offset.value / (sliderWidth - thumbSize);
+    const nextScale = 0.8 + ratio * (1.4 - 0.8);
+    setFontScale(parseFloat(nextScale.toFixed(2)));
+    Haptics.selectionAsync();
+  };
+
+  return (
+    <NeonBackground>
+      <View style={[styles.container, { padding: theme.spacing.lg }]}
+ accessibilityRole="main">
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Settings</Text>
+        <NeonCard>
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: theme.colors.text }]}>Dark Mode</Text>
+            <Switch value={mode === 'dark'} onValueChange={toggleMode} />
+          </View>
+          <Text style={[styles.section, { color: theme.colors.text }]}>Accent</Text>
+          <View style={styles.row}>
+            {accentOptions.map(option => (
+              <Pressable
+                key={option}
+                onPress={() => {
+                  setAccent(option);
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                }}
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                  marginRight: 12,
+                  backgroundColor: accentPalette[option].primary,
+                  borderWidth: theme.colors.accent === accentPalette[option].primary ? 2 : 0,
+                  borderColor: theme.colors.text
+                }}
+              />
+            ))}
+          </View>
+          <Text style={[styles.section, { color: theme.colors.text }]}>Font Scale</Text>
+          <PanGestureHandler onHandlerStateChange={handleCommitFontScale} onGestureEvent={onGesture}>
+            <Animated.View style={[styles.slider, { backgroundColor: theme.colors.surfaceAlt }]}>
+              <Animated.View style={[styles.thumb, animatedThumb, { backgroundColor: theme.colors.accent }]} />
+            </Animated.View>
+          </PanGestureHandler>
+        </NeonCard>
+      </View>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    marginBottom: 24
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16
+  },
+  label: {
+    fontSize: 16,
+    flex: 1,
+    fontWeight: '600'
+  },
+  section: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12
+  },
+  slider: {
+    width: sliderWidth,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    paddingHorizontal: 8
+  },
+  thumb: {
+    width: thumbSize,
+    height: thumbSize,
+    borderRadius: thumbSize / 2
+  }
+});

--- a/src/screens/Skrybe/index.tsx
+++ b/src/screens/Skrybe/index.tsx
@@ -1,0 +1,104 @@
+// Step 17: Skrybe creative hub UI with note editor
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TextInput, ScrollView } from 'react-native';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useToast } from '../../components/ToastProvider';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useSkrybeStore } from '../../state/skrybeStore';
+
+export const SkrybeScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { notes, hydrate, addNote, deleteNote } = useSkrybeStore();
+  const [title, setTitle] = useState('Manifesto Pulse');
+  const [body, setBody] = useState('Sketch your future sprint...');
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  const wordCount = body.trim().split(/\s+/).filter(Boolean).length;
+
+  return (
+    <NeonBackground>
+      <ScrollView contentContainerStyle={{ padding: theme.spacing.lg, gap: theme.spacing.lg }}>
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Skrybe Forge</Text>
+        <NeonCard>
+          <Text style={[styles.subheading, { color: theme.colors.text }]}>Compose</Text>
+          <TextInput
+            value={title}
+            onChangeText={setTitle}
+            style={[styles.input, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Title"
+            placeholderTextColor={theme.colors.textMuted}
+          />
+          <TextInput
+            value={body}
+            onChangeText={setBody}
+            style={[styles.textarea, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Write your neon note"
+            placeholderTextColor={theme.colors.textMuted}
+            multiline
+          />
+          <Text style={{ color: theme.colors.textMuted, marginBottom: theme.spacing.sm }}>
+            Word count: {wordCount}
+          </Text>
+          <NeonButton
+            label="Save Note"
+            onPress={async () => {
+              await addNote(title, body);
+              showToast('Skrybe entry saved.');
+            }}
+          />
+        </NeonCard>
+        {notes.map(note => (
+          <NeonCard key={note.id}>
+            <Text style={[styles.noteTitle, { color: theme.colors.accent }]}>{note.title}</Text>
+            <Text style={{ color: theme.colors.text, marginTop: theme.spacing.xs }}>{note.body}</Text>
+            <Text style={{ color: theme.colors.textMuted, marginTop: theme.spacing.xs }}>
+              {new Date(note.updated_at).toLocaleString()} — {note.word_count} words
+            </Text>
+            <NeonButton
+              label="Delete"
+              onPress={async () => {
+                await deleteNote(note.id ?? 0);
+                showToast('Note removed.');
+              }}
+            />
+          </NeonCard>
+        ))}
+      </ScrollView>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 30,
+    fontWeight: '700'
+  },
+  subheading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 12,
+    marginBottom: 12
+  },
+  textarea: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 12,
+    minHeight: 120,
+    marginBottom: 12
+  },
+  noteTitle: {
+    fontSize: 18,
+    fontWeight: '700'
+  }
+});

--- a/src/screens/Stryke/index.tsx
+++ b/src/screens/Stryke/index.tsx
@@ -1,0 +1,66 @@
+// Step 14: Stryke branching scenario UI with animated options
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useStrykeStore } from '../../state/strykeStore';
+
+export const StrykeScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { currentScenario, choose, hydrate, history } = useStrykeStore();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <NeonBackground>
+      <View style={[styles.container, { padding: theme.spacing.lg }]}
+ accessibilityRole="main">
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Stryke Protocol</Text>
+        <NeonCard>
+          <Text style={[styles.title, { color: theme.colors.accent }]}>{currentScenario.title}</Text>
+          <Text style={{ color: theme.colors.text, marginBottom: theme.spacing.md }}>
+            {currentScenario.description}
+          </Text>
+          {currentScenario.options.map(option => (
+            <Animated.View key={option.id} entering={FadeIn} exiting={FadeOut} style={{ marginBottom: 12 }}>
+              <NeonButton label={option.label} onPress={() => choose(option)} />
+            </Animated.View>
+          ))}
+        </NeonCard>
+        <NeonCard style={{ marginTop: theme.spacing.lg }}>
+          <Text style={[styles.subheading, { color: theme.colors.text }]}>Recent Outcomes</Text>
+          {history.map(choice => (
+            <Text key={choice.id} style={{ color: theme.colors.textMuted, marginTop: 8 }}>
+              {choice.option_id}: {choice.effect}
+            </Text>
+          ))}
+        </NeonCard>
+      </View>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    marginBottom: 24
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 12
+  },
+  subheading: {
+    fontSize: 16,
+    fontWeight: '600'
+  }
+});

--- a/src/screens/Tree/index.tsx
+++ b/src/screens/Tree/index.tsx
@@ -1,0 +1,106 @@
+// Step 15: Tree goal map screen with collapsible sections
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+import Animated, { Layout, FadeIn } from 'react-native-reanimated';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useTreeStore } from '../../state/treeStore';
+
+export const TreeScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { nodes, expanded, hydrate, toggleNode, addNode } = useTreeStore();
+  const [title, setTitle] = useState('New Goal Node');
+  const [hint, setHint] = useState('Drop a guiding mantra.');
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  const rootNodes = nodes.filter(node => node.parent_id === null);
+
+  return (
+    <NeonBackground>
+      <View style={[styles.container, { padding: theme.spacing.lg }]}
+ accessibilityRole="main">
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Goal Tree</Text>
+        <NeonCard>
+          <Text style={[styles.subheading, { color: theme.colors.text }]}>Add Node</Text>
+          <TextInput
+            value={title}
+            onChangeText={setTitle}
+            style={[styles.input, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Title"
+            placeholderTextColor={theme.colors.textMuted}
+          />
+          <TextInput
+            value={hint}
+            onChangeText={setHint}
+            style={[styles.input, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Hint"
+            placeholderTextColor={theme.colors.textMuted}
+          />
+          <NeonButton
+            label="Plant Node"
+            onPress={() =>
+              addNode({ parent_id: null, title, hint, created_at: Date.now() })
+            }
+          />
+        </NeonCard>
+        {rootNodes.map(node => {
+          const isExpanded = expanded[node.id ?? 0];
+          const children = nodes.filter(child => child.parent_id === node.id);
+          return (
+            <NeonCard key={node.id}>
+              <Text
+                style={[styles.nodeTitle, { color: theme.colors.accent }]}
+                onPress={() => toggleNode(node.id ?? 0)}
+                accessibilityRole="button"
+              >
+                {node.title}
+              </Text>
+              <Text style={{ color: theme.colors.textMuted }}>{node.hint}</Text>
+              {isExpanded && (
+                <Animated.View entering={FadeIn} layout={Layout.springify()} style={{ marginTop: 12 }}>
+                  {children.map(child => (
+                    <Text key={child.id} style={{ color: theme.colors.text, marginTop: 4 }}>
+                      ↳ {child.title}
+                    </Text>
+                  ))}
+                </Animated.View>
+              )}
+            </NeonCard>
+          );
+        })}
+      </View>
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  heading: {
+    fontSize: 30,
+    fontWeight: '700',
+    marginBottom: 24
+  },
+  subheading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 12,
+    marginBottom: 12
+  },
+  nodeTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 4
+  }
+});

--- a/src/screens/Zone/index.tsx
+++ b/src/screens/Zone/index.tsx
@@ -1,0 +1,100 @@
+// Step 16: Zone community feed with composer + moderation
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, ScrollView, Share } from 'react-native';
+import { NeonBackground } from '../../components/NeonBackground';
+import { NeonCard } from '../../components/NeonCard';
+import { NeonButton } from '../../components/NeonButton';
+import { useToast } from '../../components/ToastProvider';
+import { useNeonTheme } from '../../theme/ThemeProvider';
+import { useZoneStore } from '../../state/zoneStore';
+import { NeoMascot } from '../../components/NeoMascot';
+
+export const ZoneScreen: React.FC = () => {
+  const { theme } = useNeonTheme();
+  const { posts, hydrate, createPost, togglePin } = useZoneStore();
+  const [body, setBody] = useState('Dropping my first neon win.');
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  return (
+    <NeonBackground>
+      <ScrollView contentContainerStyle={{ padding: theme.spacing.lg, gap: theme.spacing.lg }}>
+        <Text style={[styles.heading, { color: theme.colors.text }]}>Zone Broadcast</Text>
+        <NeonCard>
+          <Text style={[styles.subheading, { color: theme.colors.text }]}>Share a pulse</Text>
+          <TextInput
+            value={body}
+            onChangeText={setBody}
+            style={[styles.input, { color: theme.colors.text, borderColor: theme.colors.border }]}
+            placeholder="Your neon broadcast"
+            placeholderTextColor={theme.colors.textMuted}
+            multiline
+          />
+          <View style={{ flexDirection: 'row', gap: 12 }}>
+            <View style={{ flex: 1 }}>
+              <NeonButton
+                label="Send"
+                onPress={async () => {
+                  const ok = await createPost('You', body);
+                  if (ok) {
+                    showToast('Transmission sent to the Zone.');
+                  }
+                }}
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <NeonButton
+                label="Share"
+                onPress={() =>
+                  Share.share({
+                    message: 'Join me in the Vyral Verse Zone: vyral://zone'
+                  })
+                }
+              />
+            </View>
+          </View>
+        </NeonCard>
+        {posts.map(post => (
+          <NeonCard key={post.id}>
+            <Text style={[styles.author, { color: theme.colors.accent }]}>{post.author}</Text>
+            <Text style={{ color: theme.colors.text, marginTop: theme.spacing.xs }}>{post.body}</Text>
+            <Text style={{ color: theme.colors.textMuted, marginTop: theme.spacing.xs }}>
+              {new Date(post.created_at).toLocaleString()}
+            </Text>
+            <NeonButton
+              label={post.pinned ? 'Unpin' : 'Pin'}
+              onPress={() => togglePin(post.id ?? 0, !post.pinned)}
+            />
+          </NeonCard>
+        ))}
+      </ScrollView>
+      <NeoMascot />
+    </NeonBackground>
+  );
+};
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 30,
+    fontWeight: '700'
+  },
+  subheading: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 12,
+    minHeight: 80,
+    marginBottom: 12
+  },
+  author: {
+    fontSize: 16,
+    fontWeight: '700'
+  }
+});

--- a/src/state/coreStore.ts
+++ b/src/state/coreStore.ts
@@ -1,0 +1,49 @@
+// Step 11: Core chat store orchestrating messages with optimistic updates
+import { create } from 'zustand';
+import { CoreMessagesRepo, CoreMessage } from '../data/repos/coreMessagesRepo';
+import { sanitizeMessage, isMessageAllowed } from '../util/filters';
+import { useNeoStore } from './neoStore';
+
+export type CoreStore = {
+  channel: string;
+  messages: CoreMessage[];
+  loading: boolean;
+  load: (channel?: string) => Promise<void>;
+  sendMessage: (content: string, author?: string) => Promise<boolean>;
+};
+
+export const useCoreStore = create<CoreStore>((set, get) => ({
+  channel: 'core',
+  messages: [],
+  loading: false,
+  load: async (channel = 'core') => {
+    set({ loading: true, channel });
+    const records = await CoreMessagesRepo.list(channel);
+    set({ messages: records, loading: false });
+  },
+  sendMessage: async (content: string, author = 'You') => {
+    if (!isMessageAllowed(content)) {
+      useNeoStore.getState().trigger('alert', 'Message flagged — keep it neon-positive.');
+      return false;
+    }
+    const sanitized = sanitizeMessage(content);
+    const optimistic: CoreMessage = {
+      id: Date.now(),
+      channel: get().channel,
+      author,
+      content: sanitized,
+      avatar: 'user',
+      created_at: Date.now()
+    };
+    set(state => ({ messages: [...state.messages, optimistic] }));
+    try {
+      await CoreMessagesRepo.add({ ...optimistic, id: undefined });
+      useNeoStore.getState().trigger('celebrate', 'Neo logged the pulse.');
+      return true;
+    } catch (error) {
+      set(state => ({ messages: state.messages.filter(msg => msg.id !== optimistic.id) }));
+      useNeoStore.getState().trigger('alert', 'Signal lost — retry that drop.');
+      return false;
+    }
+  }
+}));

--- a/src/state/lyfeStore.ts
+++ b/src/state/lyfeStore.ts
@@ -1,0 +1,77 @@
+// Step 11 & 13: Lyfe lessons store with AI generator integration
+import { create } from 'zustand';
+import * as Notifications from 'expo-notifications';
+import { LyfeLessonsRepo, LyfeLesson, LyfeProgress } from '../data/repos/lyfeLessonsRepo';
+import { buildLessonOutline } from '../ai/lessons';
+import { useNeoStore } from './neoStore';
+
+export type LyfeState = {
+  lessons: LyfeLesson[];
+  progress: LyfeProgress[];
+  loading: boolean;
+  generateLesson: (topic: string) => Promise<void>;
+  markComplete: (lessonId: number) => Promise<void>;
+  scheduleReminder: (lessonId: number, minutesFromNow?: number) => Promise<void>;
+  hydrate: () => Promise<void>;
+};
+
+export const useLyfeStore = create<LyfeState>((set, get) => ({
+  lessons: [],
+  progress: [],
+  loading: false,
+  hydrate: async () => {
+    set({ loading: true });
+    const [lessons, progress] = await Promise.all([
+      LyfeLessonsRepo.list(),
+      LyfeLessonsRepo.listProgress()
+    ]);
+    set({ lessons, progress, loading: false });
+  },
+  generateLesson: async (topic: string) => {
+    set({ loading: true });
+    const outline = await buildLessonOutline(topic);
+    const record = await LyfeLessonsRepo.add({
+      topic: outline.topic,
+      outline: JSON.stringify(outline.bullets),
+      created_at: Date.now()
+    });
+    await LyfeLessonsRepo.upsertProgress({
+      lesson_id: record.id ?? 0,
+      status: 'in-progress',
+      xp: 0,
+      completed_at: null
+    });
+    await get().scheduleReminder(record.id ?? 0, 30);
+    await get().hydrate();
+    useNeoStore.getState().trigger('hint', 'Fresh Lyfe lesson ignited — absorb the pulse.');
+  },
+  markComplete: async (lessonId: number) => {
+    const progress = get().progress.find(item => item.lesson_id === lessonId);
+    const currentXp = progress?.xp ?? 0;
+    await LyfeLessonsRepo.upsertProgress({
+      lesson_id: lessonId,
+      status: 'complete',
+      xp: currentXp + 100,
+      completed_at: Date.now()
+    });
+    await get().hydrate();
+    useNeoStore.getState().trigger('celebrate', 'Lesson complete — XP surge synced.');
+  },
+  scheduleReminder: async (lessonId: number, minutesFromNow = 30) => {
+    try {
+      const permission = await Notifications.requestPermissionsAsync();
+      if (!permission.granted) {
+        return;
+      }
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'Lyfe Pulse',
+          body: 'Loop back to your neon lesson before the glow fades.'
+        },
+        trigger: { seconds: minutesFromNow * 60 }
+      });
+    } catch (error) {
+      console.warn('Failed to schedule reminder', error);
+    }
+  }
+}));

--- a/src/state/neoStore.ts
+++ b/src/state/neoStore.ts
@@ -1,0 +1,29 @@
+// Step 19: Neo assistant finite-state machine
+import { create } from 'zustand';
+
+export type NeoState = 'idle' | 'hint' | 'celebrate' | 'alert';
+
+type NeoStore = {
+  state: NeoState;
+  message: string | null;
+  lastTriggeredAt?: number;
+  trigger: (state: NeoState, message: string) => void;
+  acknowledge: () => void;
+};
+
+const COOLDOWN_MS = 60 * 1000;
+
+export const useNeoStore = create<NeoStore>(set => ({
+  state: 'idle',
+  message: null,
+  lastTriggeredAt: undefined,
+  trigger: (state, message) =>
+    set(current => {
+      const now = Date.now();
+      if (current.lastTriggeredAt && now - current.lastTriggeredAt < COOLDOWN_MS) {
+        return current;
+      }
+      return { state, message, lastTriggeredAt: now };
+    }),
+  acknowledge: () => set({ state: 'idle', message: null })
+}));

--- a/src/state/skrybeStore.ts
+++ b/src/state/skrybeStore.ts
@@ -1,0 +1,35 @@
+// Step 17: Skrybe notes store with live word count
+import { create } from 'zustand';
+import { SkrybeNotesRepo, SkrybeNote } from '../data/repos/skrybeNotesRepo';
+
+export type SkrybeState = {
+  notes: SkrybeNote[];
+  loading: boolean;
+  hydrate: () => Promise<void>;
+  addNote: (title: string, body: string) => Promise<void>;
+  deleteNote: (id: number) => Promise<void>;
+};
+
+export const useSkrybeStore = create<SkrybeState>((set, get) => ({
+  notes: [],
+  loading: false,
+  hydrate: async () => {
+    set({ loading: true });
+    const notes = await SkrybeNotesRepo.list();
+    set({ notes, loading: false });
+  },
+  addNote: async (title, body) => {
+    const wordCount = body.trim().split(/\s+/).filter(Boolean).length;
+    await SkrybeNotesRepo.add({
+      title,
+      body,
+      word_count: wordCount,
+      updated_at: Date.now()
+    });
+    await get().hydrate();
+  },
+  deleteNote: async id => {
+    await SkrybeNotesRepo.remove(id);
+    await get().hydrate();
+  }
+}));

--- a/src/state/strykeStore.ts
+++ b/src/state/strykeStore.ts
@@ -1,0 +1,71 @@
+// Step 14: Stryke decision engine with persistent log
+import { create } from 'zustand';
+import { StrykeChoicesRepo, StrykeChoice } from '../data/repos/strykeChoicesRepo';
+
+export type ScenarioOption = {
+  id: string;
+  label: string;
+  effect: string;
+};
+
+export type Scenario = {
+  id: string;
+  title: string;
+  description: string;
+  options: ScenarioOption[];
+};
+
+const scenarios: Scenario[] = [
+  {
+    id: 'ignition',
+    title: 'Ignition Point',
+    description: 'Your squad hits a midnight creative sprint. Choose the boost.',
+    options: [
+      { id: 'pulse', label: 'Deploy Pulse Playlist', effect: '+5 focus' },
+      { id: 'silence', label: 'Initiate Silent Sync', effect: '+3 calm' }
+    ]
+  },
+  {
+    id: 'momentum',
+    title: 'Momentum Fork',
+    description: 'Momentum dips post-launch. How do you rally?',
+    options: [
+      { id: 'retrospective', label: 'Run a flash retro', effect: 'Clarity restored' },
+      { id: 'celebrate', label: 'Micro celebrate win', effect: 'Morale boost' }
+    ]
+  }
+];
+
+export type StrykeState = {
+  history: StrykeChoice[];
+  currentScenarioIndex: number;
+  loading: boolean;
+  currentScenario: Scenario;
+  choose: (option: ScenarioOption) => Promise<void>;
+  hydrate: () => Promise<void>;
+};
+
+export const useStrykeStore = create<StrykeState>((set, get) => ({
+  history: [],
+  currentScenarioIndex: 0,
+  loading: false,
+  currentScenario: scenarios[0],
+  hydrate: async () => {
+    set({ loading: true });
+    const scenario = scenarios[get().currentScenarioIndex];
+    const choices = await StrykeChoicesRepo.listByScenario(scenario.id);
+    set({ history: choices, loading: false });
+  },
+  choose: async option => {
+    const scenario = scenarios[get().currentScenarioIndex];
+    await StrykeChoicesRepo.add({
+      scenario_id: scenario.id,
+      option_id: option.id,
+      effect: option.effect,
+      created_at: Date.now()
+    });
+    const nextIndex = (get().currentScenarioIndex + 1) % scenarios.length;
+    set({ currentScenarioIndex: nextIndex, currentScenario: scenarios[nextIndex] });
+    await get().hydrate();
+  }
+}));

--- a/src/state/treeStore.ts
+++ b/src/state/treeStore.ts
@@ -1,0 +1,31 @@
+// Step 15: Tree goal graph store with expand/collapse persistence
+import { create } from 'zustand';
+import { TreeNodesRepo, TreeNodeRecord } from '../data/repos/treeNodesRepo';
+
+type TreeState = {
+  nodes: TreeNodeRecord[];
+  expanded: Record<number, boolean>;
+  loading: boolean;
+  hydrate: () => Promise<void>;
+  toggleNode: (id: number) => void;
+  addNode: (payload: Omit<TreeNodeRecord, 'id'>) => Promise<void>;
+};
+
+export const useTreeStore = create<TreeState>((set, get) => ({
+  nodes: [],
+  expanded: {},
+  loading: false,
+  hydrate: async () => {
+    set({ loading: true });
+    const roots = await TreeNodesRepo.listChildren(null);
+    const childrenPromises = roots.map(root => TreeNodesRepo.listChildren(root.id ?? 0));
+    const children = await Promise.all(childrenPromises);
+    set({ nodes: [...roots, ...children.flat()], loading: false });
+  },
+  toggleNode: id =>
+    set(state => ({ expanded: { ...state.expanded, [id]: !state.expanded[id] } })),
+  addNode: async payload => {
+    await TreeNodesRepo.add(payload);
+    await get().hydrate();
+  }
+}));

--- a/src/state/zoneStore.ts
+++ b/src/state/zoneStore.ts
@@ -1,0 +1,49 @@
+// Step 11 & 16: Zone feed store handling community posts
+import { create } from 'zustand';
+import { ZonePostsRepo, ZonePost } from '../data/repos/zonePostsRepo';
+import { sanitizeMessage, isMessageAllowed } from '../util/filters';
+import { useNeoStore } from './neoStore';
+
+export type ZoneState = {
+  posts: ZonePost[];
+  loading: boolean;
+  hydrate: () => Promise<void>;
+  createPost: (author: string, body: string) => Promise<boolean>;
+  deletePost: (id: number) => Promise<void>;
+  togglePin: (id: number, pinned: boolean) => Promise<void>;
+};
+
+export const useZoneStore = create<ZoneState>((set, get) => ({
+  posts: [],
+  loading: false,
+  hydrate: async () => {
+    set({ loading: true });
+    const posts = await ZonePostsRepo.list();
+    set({ posts, loading: false });
+  },
+  createPost: async (author, body) => {
+    if (!isMessageAllowed(body)) {
+      useNeoStore.getState().trigger('alert', 'Zone post blocked — elevate the signal.');
+      return false;
+    }
+    const sanitized = sanitizeMessage(body);
+    await ZonePostsRepo.add({
+      author,
+      body: sanitized,
+      pinned: 0,
+      reactions: 0,
+      created_at: Date.now()
+    });
+    await get().hydrate();
+    useNeoStore.getState().trigger('celebrate', 'First Zone transmission locked.');
+    return true;
+  },
+  deletePost: async id => {
+    await ZonePostsRepo.delete(id);
+    await get().hydrate();
+  },
+  togglePin: async (id, pinned) => {
+    await ZonePostsRepo.updatePinned(id, pinned);
+    await get().hydrate();
+  }
+}));

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,0 +1,71 @@
+// Step 5: Theme provider bridging Zustand store and React context
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { buildTheme, NeonAccent, ThemeTokens } from './tokens';
+
+export type ThemeStore = {
+  mode: 'dark' | 'light';
+  accent: NeonAccent;
+  fontScale: number;
+  toggleMode: () => void;
+  setAccent: (accent: NeonAccent) => void;
+  setFontScale: (scale: number) => void;
+};
+
+const useThemeStore = create<ThemeStore>()(
+  persist(
+    set => ({
+      mode: 'dark',
+      accent: 'violet',
+      fontScale: 1,
+      toggleMode: () => set(state => ({ mode: state.mode === 'dark' ? 'light' : 'dark' })),
+      setAccent: accent => set({ accent }),
+      setFontScale: fontScale => set({ fontScale })
+    }),
+    {
+      name: 'vyral-theme',
+      storage: createJSONStorage(() => AsyncStorage)
+    }
+  )
+);
+
+type ThemeContextValue = {
+  theme: ThemeTokens;
+  mode: 'dark' | 'light';
+  accent: NeonAccent;
+  fontScale: number;
+  toggleMode: () => void;
+  setAccent: (accent: NeonAccent) => void;
+  setFontScale: (scale: number) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { mode, accent, fontScale, toggleMode, setAccent, setFontScale } = useThemeStore();
+
+  const theme = useMemo(() => buildTheme(mode, accent, fontScale), [mode, accent, fontScale]);
+
+  useEffect(() => {
+    // Step 5: we could hook analytics or logging for theme changes here
+  }, [mode, accent, fontScale]);
+
+  const value = useMemo(
+    () => ({ theme, mode, accent, fontScale, toggleMode, setAccent, setFontScale }),
+    [theme, mode, accent, fontScale, toggleMode, setAccent, setFontScale]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useNeonTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useNeonTheme must be used inside ThemeProvider');
+  }
+  return context;
+};
+
+export const useThemeStoreBase = useThemeStore;

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,0 +1,85 @@
+// Step 5: Neon-first design tokens powering the global theme
+export type NeonAccent = 'violet' | 'cyan' | 'magenta' | 'emerald';
+
+export const baseColors = {
+  dark: {
+    background: '#04010F',
+    surface: '#0B0720',
+    surfaceAlt: '#110C2F',
+    border: '#1F1B3B',
+    text: '#F5F5FF',
+    textMuted: '#B0B0D0',
+    warning: '#FF7A7A'
+  },
+  light: {
+    background: '#F5F5FF',
+    surface: '#EBE7FF',
+    surfaceAlt: '#E1D8FF',
+    border: '#C0B9F2',
+    text: '#120A3D',
+    textMuted: '#4A3E7D',
+    warning: '#C44D56'
+  }
+};
+
+export const accentPalette: Record<NeonAccent, { primary: string; secondary: string }> = {
+  violet: { primary: '#7F5BFF', secondary: '#14F0FF' },
+  cyan: { primary: '#00D4FF', secondary: '#6C5BFF' },
+  magenta: { primary: '#FF3FD1', secondary: '#7F5BFF' },
+  emerald: { primary: '#38F4B5', secondary: '#00D4FF' }
+};
+
+export const radii = {
+  xs: 8,
+  sm: 12,
+  md: 16,
+  lg: 24,
+  full: 999
+};
+
+export const spacing = {
+  xxs: 4,
+  xs: 8,
+  sm: 12,
+  md: 16,
+  lg: 24,
+  xl: 32
+};
+
+export const shadows = {
+  neon(accent: NeonAccent) {
+    return {
+      shadowColor: accentPalette[accent].primary,
+      shadowOffset: { width: 0, height: 12 },
+      shadowOpacity: 0.35,
+      shadowRadius: 32,
+      elevation: 18
+    };
+  }
+};
+
+export type ThemeTokens = {
+  mode: 'dark' | 'light';
+  colors: typeof baseColors.dark & { accent: string; accentSecondary: string };
+  radii: typeof radii;
+  spacing: typeof spacing;
+  shadows: typeof shadows;
+  fontScale: number;
+};
+
+export const buildTheme = (mode: 'dark' | 'light', accent: NeonAccent, fontScale: number): ThemeTokens => {
+  const palette = mode === 'dark' ? baseColors.dark : baseColors.light;
+  const accentColors = accentPalette[accent];
+  return {
+    mode,
+    colors: {
+      ...palette,
+      accent: accentColors.primary,
+      accentSecondary: accentColors.secondary
+    },
+    radii,
+    spacing,
+    shadows,
+    fontScale
+  };
+};

--- a/src/util/filters.ts
+++ b/src/util/filters.ts
@@ -1,0 +1,17 @@
+// Step 12 & 30: Simple moderation filters to sanitize user content
+const blacklist = ['spam', 'scam', 'toxic'];
+const whitelist = ['vyral', 'neon', 'flow', 'momentum'];
+
+export const sanitizeMessage = (input: string): string => {
+  let output = input;
+  for (const word of blacklist) {
+    const pattern = new RegExp(word, 'gi');
+    output = output.replace(pattern, '⚠️');
+  }
+  return output;
+};
+
+export const isMessageAllowed = (input: string): boolean => {
+  const lower = input.toLowerCase();
+  return whitelist.some(word => lower.includes(word)) || !blacklist.some(word => lower.includes(word));
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": ["DOM", "ES2019"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["react", "react-native", "jest"]
+  },
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
## Summary
- bootstrap Expo TypeScript workspace with neon-themed assets, config, and tooling for the Vyral Verse OS vision
- stand up navigation shell, theme provider, toast/error scaffolding, and persisted SQLite data layer with repositories and demo seed data
- implement Core, Lyfe, Stryke, Tree, Zone, Skrybe, and Settings screens using reusable neon UI primitives, state stores, and the animated Neo mascot assistant
- replace bundled binary artwork with procedural neon gradients and glyph components so the experience remains asset-free

## Testing
- npm run lint *(fails: @eslint/js is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96f3129308321b63b932a51102c30