### PR TITLE
Avoid JSX in entry point to prevent ESM syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,15 @@ if (__DEV__) {
   }
 }
 
-const Root = () => (
-  <GestureHandlerRootView style={{ flex: 1 }}>
-    <App />
-  </GestureHandlerRootView>
-);
+const rootViewStyle = Object.freeze({ flex: 1 });
+
+function Root() {
+  return React.createElement(
+    GestureHandlerRootView,
+    { style: rootViewStyle },
+    React.createElement(App)
+  );
+}
 
 registerRootComponent(Root);
 


### PR DESCRIPTION
## Summary
- replace the JSX wrapper in `index.js` with `React.createElement` so Node can parse the entry module
- reuse a frozen style object for the gesture handler root view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deee01474c8321a65e6cabc65520aa