### PR TITLE
Add module asset lineup to dashboard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,8 +6,83 @@ import { VyraSkillTree } from './components/VyraSkillTree';
 import { LensCoreInterface } from './components/LensCoreInterface';
 import { useVerseStore } from './src/hooks/useVerseStore';
 import type { Quest } from '@core/types';
+import StrykeIcon from './assets/modules/stryke.svg';
+import KorIcon from './assets/modules/kor.svg';
+import ZoneIcon from './assets/modules/zone.svg';
+import SkrybeIcon from './assets/modules/skrybe.svg';
+import LyfeIcon from './assets/modules/lyfe.svg';
+import TreeIcon from './assets/modules/tree.svg';
+import BoardIcon from './assets/modules/board.svg';
+import ShopIcon from './assets/modules/shop.svg';
 
 const XP_PER_LEVEL = 500;
+
+type ModuleCard = {
+  id: string;
+  name: string;
+  description: string;
+  cta: string;
+  icon: string;
+};
+
+const moduleLineup: ModuleCard[] = [
+  {
+    id: 'stryke',
+    name: 'Stryke',
+    description: 'Deploy lightning-fast focus rituals and micro challenges when the grind demands instant energy.',
+    cta: 'Launch Stryke',
+    icon: StrykeIcon,
+  },
+  {
+    id: 'kor',
+    name: 'Kor',
+    description: 'Anchor your mission blueprint, calibrate core values, and lock the squad ethos for the cycle.',
+    cta: 'Enter Kor',
+    icon: KorIcon,
+  },
+  {
+    id: 'zone',
+    name: 'Zone',
+    description: 'Broadcast transmissions, amplify crew hype, and monitor the $Lyfe economy pulses in real time.',
+    cta: 'Open Zone',
+    icon: ZoneIcon,
+  },
+  {
+    id: 'skrybe',
+    name: 'Skrybe',
+    description: 'Summon questlines, devotionals, and narrative echoes from the AI scribe to fuel the storyline.',
+    cta: 'Invoke Skrybe',
+    icon: SkrybeIcon,
+  },
+  {
+    id: 'lyfe',
+    name: 'Lyfe',
+    description: 'Track momentum metrics, XP surges, and orbit-wide vitality to steer your next move.',
+    cta: 'View Lyfe',
+    icon: LyfeIcon,
+  },
+  {
+    id: 'tree',
+    name: 'Tree',
+    description: 'Grow your multi-branch skill canopy, visualize routes, and queue the next unlock.',
+    cta: 'Grow Tree',
+    icon: TreeIcon,
+  },
+  {
+    id: 'board',
+    name: 'Board',
+    description: 'Map goals, align quests, and orchestrate cosmic sprints across your mission board.',
+    cta: 'Chart Board',
+    icon: BoardIcon,
+  },
+  {
+    id: 'shop',
+    name: 'Shop',
+    description: 'Trade neon currency for skins, boosters, and Verse upgrades to mod your run.',
+    cta: 'Visit Shop',
+    icon: ShopIcon,
+  },
+];
 
 const formatTimeAgo = (timestamp: number) => {
   const diff = Date.now() - timestamp;
@@ -157,6 +232,33 @@ export default function App() {
                       <span className="value">{store.seeds.length}</span>
                       <span className="subtext">Ideas planted in the grove</span>
                     </div>
+                  </div>
+                </section>
+
+                <section className="panel module-access" aria-labelledby="module-access-title">
+                  <div className="panel-header">
+                    <div className="panel-title">
+                      <img src={moduleLineup[0]?.icon} alt="" aria-hidden="true" />
+                      <h2 id="module-access-title">Verse Modules</h2>
+                    </div>
+                    <span>Core systems at your command</span>
+                  </div>
+                  <div className="module-grid" role="list">
+                    {moduleLineup.map((module) => (
+                      <article
+                        key={module.id}
+                        className="module-card"
+                        role="listitem"
+                        aria-label={`${module.name} module card`}
+                      >
+                        <div className="module-card__icon">
+                          <img src={module.icon} alt={`${module.name} emblem`} loading="lazy" />
+                        </div>
+                        <h3>{module.name}</h3>
+                        <p>{module.description}</p>
+                        <span className="module-card__cta">{module.cta}</span>
+                      </article>
+                    ))}
                   </div>
                 </section>
 

--- a/assets/modules/board.svg
+++ b/assets/modules/board.svg
@@ -1,0 +1,27 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="board-bg" x1="52" y1="44" x2="204" y2="212" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101E31" />
+      <stop offset="1" stop-color="#02060D" />
+    </linearGradient>
+    <linearGradient id="board-lines" x1="88" y1="72" x2="184" y2="184" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6FFAFF" />
+      <stop offset="1" stop-color="#2A7EFF" />
+    </linearGradient>
+    <filter id="board-glow" x="44" y="36" width="168" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#board-bg)" />
+  <g filter="url(#board-glow)" stroke="url(#board-lines)" stroke-width="12" stroke-linecap="round">
+    <rect x="76" y="76" width="104" height="104" rx="18" />
+    <path d="M76 128H180" />
+    <path d="M128 76V180" />
+    <path d="M100 156H116" />
+    <path d="M140 100H156" />
+  </g>
+</svg>

--- a/assets/modules/kor.svg
+++ b/assets/modules/kor.svg
@@ -1,0 +1,23 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="kor-bg" x1="48" y1="40" x2="208" y2="216" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101D30" />
+      <stop offset="1" stop-color="#04070E" />
+    </linearGradient>
+    <linearGradient id="kor-tri" x1="92" y1="72" x2="180" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#63F1FF" />
+      <stop offset="1" stop-color="#2A7DFF" />
+    </linearGradient>
+    <filter id="kor-glow" x="44" y="36" width="168" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#kor-bg)" />
+  <path filter="url(#kor-glow)" fill="none" stroke="url(#kor-tri)" stroke-width="18" stroke-linejoin="round"
+    d="M128 64L188 192H68L128 64Z" />
+  <path opacity="0.3" stroke="#6CEBFF" stroke-width="6" stroke-linecap="round" d="M128 98L158 160H98L128 98Z" />
+</svg>

--- a/assets/modules/lyfe.svg
+++ b/assets/modules/lyfe.svg
@@ -1,0 +1,25 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lyfe-bg" x1="52" y1="44" x2="204" y2="212" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101D30" />
+      <stop offset="1" stop-color="#04070E" />
+    </linearGradient>
+    <linearGradient id="lyfe-line" x1="92" y1="72" x2="188" y2="188" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6DF7FF" />
+      <stop offset="1" stop-color="#2A7EFF" />
+    </linearGradient>
+    <filter id="lyfe-glow" x="40" y="36" width="176" height="184" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#lyfe-bg)" />
+  <g filter="url(#lyfe-glow)" stroke="url(#lyfe-line)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M68 168L116 124L148 152L196 92" />
+    <path d="M196 92V140" />
+    <path d="M196 92H148" />
+  </g>
+</svg>

--- a/assets/modules/shop.svg
+++ b/assets/modules/shop.svg
@@ -1,0 +1,27 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="shop-bg" x1="52" y1="44" x2="208" y2="212" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101F32" />
+      <stop offset="1" stop-color="#03060D" />
+    </linearGradient>
+    <linearGradient id="shop-coin" x1="96" y1="68" x2="180" y2="188" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#71FAFF" />
+      <stop offset="1" stop-color="#2A7FFF" />
+    </linearGradient>
+    <filter id="shop-glow" x="44" y="36" width="168" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#shop-bg)" />
+  <g filter="url(#shop-glow)">
+    <circle cx="132" cy="132" r="68" stroke="url(#shop-coin)" stroke-width="14" fill="none" />
+    <path d="M120 96h20c12 0 20 6 20 16 0 10-8 16-20 16h-8v16h12" stroke="url(#shop-coin)" stroke-width="12"
+      stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M132 84v16" stroke="url(#shop-coin)" stroke-width="12" stroke-linecap="round" />
+    <path d="M132 160v16" stroke="url(#shop-coin)" stroke-width="12" stroke-linecap="round" />
+  </g>
+</svg>

--- a/assets/modules/skrybe.svg
+++ b/assets/modules/skrybe.svg
@@ -1,0 +1,25 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="skrybe-bg" x1="52" y1="44" x2="200" y2="216" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101D31" />
+      <stop offset="1" stop-color="#03060D" />
+    </linearGradient>
+    <linearGradient id="skrybe-feather" x1="92" y1="60" x2="180" y2="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6CF4FF" />
+      <stop offset="1" stop-color="#2A7EFF" />
+    </linearGradient>
+    <filter id="skrybe-glow" x="44" y="36" width="168" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#skrybe-bg)" />
+  <g filter="url(#skrybe-glow)" fill="url(#skrybe-feather)">
+    <path d="M96 172c24-64 80-120 104-120 4 0 8 0.5 10 2 3 3 3 7-1 12-24 28-60 60-100 82-6 4-9 8-13 24-1 6-3 10-8 15-7 6-17 9-24 8 0 0 6-16 32-23z" />
+    <path d="M96 172c18-18 42-30 70-34" opacity="0.6" />
+  </g>
+  <path d="M84 188c10 0 18 8 18 18" stroke="#6CF4FF" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/assets/modules/stryke.svg
+++ b/assets/modules/stryke.svg
@@ -1,0 +1,21 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="36" y1="36" x2="220" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0F1C2E" />
+      <stop offset="1" stop-color="#05080F" />
+    </linearGradient>
+    <linearGradient id="bolt" x1="92" y1="60" x2="176" y2="208" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5AD4FF" />
+      <stop offset="1" stop-color="#1B6BFF" />
+    </linearGradient>
+    <filter id="glow" x="48" y="32" width="160" height="200" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#bg)" />
+  <path filter="url(#glow)" fill="url(#bolt)" d="M150.8 52H128L96 138.5H122.4L104 204L168 124.6H139.2L150.8 52Z" />
+</svg>

--- a/assets/modules/tree.svg
+++ b/assets/modules/tree.svg
@@ -1,0 +1,29 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tree-bg" x1="52" y1="44" x2="208" y2="212" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101F31" />
+      <stop offset="1" stop-color="#03070E" />
+    </linearGradient>
+    <linearGradient id="tree-branch" x1="96" y1="60" x2="176" y2="204" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6CF6FF" />
+      <stop offset="1" stop-color="#2B7CFF" />
+    </linearGradient>
+    <filter id="tree-glow" x="44" y="36" width="168" height="196" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#tree-bg)" />
+  <g filter="url(#tree-glow)" stroke="url(#tree-branch)" stroke-width="12" stroke-linecap="round">
+    <path d="M128 196V104" />
+    <path d="M128 144L92 120" />
+    <path d="M128 128L160 112" />
+    <path d="M128 152L160 176" />
+    <path d="M128 132L100 160" />
+    <path d="M128 96L108 72" />
+    <path d="M128 96L148 72" />
+  </g>
+</svg>

--- a/assets/modules/zone.svg
+++ b/assets/modules/zone.svg
@@ -1,0 +1,27 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="zone-bg" x1="52" y1="44" x2="204" y2="212" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101D30" />
+      <stop offset="1" stop-color="#04060D" />
+    </linearGradient>
+    <linearGradient id="zone-wave" x1="88" y1="72" x2="184" y2="184" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#68F5FF" />
+      <stop offset="1" stop-color="#2D7DFF" />
+    </linearGradient>
+    <filter id="zone-glow" x="40" y="36" width="176" height="184" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="20" y="20" width="216" height="216" rx="56" fill="url(#zone-bg)" />
+  <g filter="url(#zone-glow)" stroke="url(#zone-wave)" stroke-width="12" stroke-linecap="round">
+    <circle cx="128" cy="128" r="60" fill="none" />
+    <path d="M180 128c0 28.719-23.281 52-52 52" />
+    <path d="M168 128c0 22.091-17.909 40-40 40" />
+    <path d="M156 128c0 15.464-12.536 28-28 28" />
+    <circle cx="128" cy="128" r="12" />
+  </g>
+</svg>

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,5 @@
 declare module '*.css';
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/styles/neon.css
+++ b/styles/neon.css
@@ -445,6 +445,97 @@ body {
   color: var(--accent-cyan);
 }
 
+.module-access .panel-title img {
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: rgba(96, 165, 255, 0.18);
+  padding: 4px;
+  box-shadow: 0 0 18px rgba(96, 165, 255, 0.35);
+}
+
+.module-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.module-card {
+  position: relative;
+  border-radius: var(--radius-sm);
+  padding: 18px;
+  background: rgba(9, 17, 30, 0.78);
+  border: 1px solid rgba(96, 165, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 255, 0.08);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.module-card::after {
+  content: '';
+  position: absolute;
+  inset: -80% -40% auto;
+  height: 160px;
+  background: radial-gradient(circle at 50% 120%, rgba(96, 165, 255, 0.38), rgba(96, 165, 255, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.module-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(12, 24, 44, 0.55);
+}
+
+.module-card:hover::after {
+  opacity: 1;
+}
+
+.module-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 14px;
+  box-shadow: 0 12px 30px rgba(96, 165, 255, 0.45);
+}
+
+.module-card__icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.module-card h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.module-card p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--txt-dim);
+}
+
+.module-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 16px;
+  font-size: 12px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.module-card__cta::after {
+  content: '➜';
+  font-size: 12px;
+}
+
 .list-stack {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add dedicated neon-styled SVG assets for the Stryke, Kor, Zone, Skrybe, Lyfe, Tree, Board, and Shop modules
- surface a Verse Modules panel on the dashboard that renders the lineup in the required order using the new art
- extend TypeScript global declarations so SVG assets import cleanly alongside fresh styling hooks

## Testing
- npm install *(fails: 403 Forbidden fetching @babel/core from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df09ce93588321b44a61a20b91cef4